### PR TITLE
Boundaries to the 'Root cause' definition.

### DIFF
--- a/draft-ietf-nmop-network-incident-yang.md
+++ b/draft-ietf-nmop-network-incident-yang.md
@@ -75,6 +75,10 @@ contributor:
     fullname: Chaode Yu
     organization: Huawei
     email: yuchaode@huawei.com
+-
+  fullname: Lionel Tailhardat
+  organization: Orange
+  email: lionel.tailhardat@orange.com
 
 normative:
 
@@ -204,10 +208,12 @@ and are not redefined here:
 The following terms are defined in this document:
 
 Service impact analysis:
-:  A process that uses machine learning to evaluate whether the network service
-   has been impacted by the network incident and map network incident to one or
-   a set of network service, which can reduce massive fault/alarms reporting, speed
-   up troubleshooting, and assure network service performance and availability.
+:  A process that uses algorithmic techniques (e.g., machine learning, automated
+   reasoning, conformance checking, graph traversal, among others) to evaluate
+   whether the network service has been impacted by the network incident and map
+   network incident to one or a set of network service, which can reduce massive
+   fault/alarms reporting, speed up troubleshooting, and assure network service
+   performance and availability.
 
 Incident management:
 :  Lifecycle management of network incidents, including network incident

--- a/draft-ietf-nmop-network-incident-yang.md
+++ b/draft-ietf-nmop-network-incident-yang.md
@@ -218,7 +218,6 @@ and are not redefined here:
 The following terms are defined in this document:
 
 Service impact analysis:
-
 :  A process that uses algorithmic techniques (e.g., machine learning, automated
    reasoning, conformance checking, graph traversal, among others) to evaluate
    whether the network service has been impacted by the network incident and map

--- a/draft-ietf-nmop-network-incident-yang.md
+++ b/draft-ietf-nmop-network-incident-yang.md
@@ -255,14 +255,26 @@ Root cause:
    an ongoing incident -- specifically regarding network or service impairments
    and their related consequential failures and symptoms -- and prevents the problem
    from recurring. Causality is defined as the implementation of an inductive process
-   at the network/processing element level {{ITU-T-G.7710}} and as a doubt removal
+   at the network or processing element level {{ITU-T-G.7710}} and as a doubt removal
    process at the Incident management system level {{ITU-T X.733}}. The inductive
-   process is based on the distinction made between _primary failures_ (i.e. a failure
-   that directly indicates the fault location and initiate a repair action, e.g.
-   a broken cable or a misconnection) and _secondary failures_ (i.e. a consequential
-   failure, e.g. an upper level service that is gone down) {{ITU-T-G.7710}}.
+   process is based on the distinction made between _primary failures_ (i.e., a failure
+   that directly indicates the fault location and initiate a repair action, such as
+   a broken cable or a misconnection) and _secondary failures_ (i.e., a consequential
+   failure, such as an upper level service that has gone down) {{ITU-T-G.7710}}.
+
    Conversely, a causal factor is a contributing action that influences the outcome
    of an incident or event but is not the root cause.
+
+   If further details about the root cause are required (e.g., incident diagnosis
+   based on similar posterior cases, large-scale correction of the network design
+   using a failure and defect mode analysis), root cause data can be further refined using
+   additional qualifier, such as _Proven cause_ (i.e. one that has been established
+   through tangible evidence and objective data) and _Assumed cause_ (i.e. hypothesis
+   or theory regarding the origin of the malfunction, based on observations, past experiences,
+   or general knowledge, but which has not yet been conclusively proven) to provide
+   a confidence level. Additionally, categories such as _Exogenous cause_, _Human cause_,
+   _Random cause_, and _External systemic cause_ can be used for guidance on the
+   attribution of the incident.
 
 
 # Sample Use Cases

--- a/draft-ietf-nmop-network-incident-yang.md
+++ b/draft-ietf-nmop-network-incident-yang.md
@@ -99,6 +99,7 @@ informative:
    target: https://www.w3.org/TR/2021/REC-trace-context-1-20211123/
    date: 2021
 
+
 --- abstract
 
 A network incident refers to an unexpected interruption of a network
@@ -252,13 +253,17 @@ Incident handler:
 Root cause:
 :  A factor is considered the root cause of a problem if removing it fully resolves
    an ongoing incident -- specifically regarding network or service impairments
-   and their related consequential symptoms -- and prevents the problem from recurring.
+   and their related consequential failures and symptoms -- and prevents the problem
+   from recurring. Causality is defined as the implementation of an inductive process
+   at the network/processing element level {{ITU-T-G.7710}} and as a doubt removal
+   process at the Incident management system level {{ITU-T X.733}}. The inductive
+   process is based on the distinction made between _primary failures_ (i.e. a failure
+   that directly indicates the fault location and initiate a repair action, e.g.
+   a broken cable or a misconnection) and _secondary failures_ (i.e. a consequential
+   failure, e.g. an upper level service that is gone down) {{ITU-T-G.7710}}.
    Conversely, a causal factor is a contributing action that influences the outcome
    of an incident or event but is not the root cause.
 
-  ### Root Cause
-
-      A factor is considered the root cause of a problem if removing it fully resolves an ongoing incidentand prevents the problem from recurring. Conversely, a causal factor is a contributing action that influences the outcome of an incident or event but is not the root cause.
 
 # Sample Use Cases
 

--- a/draft-ietf-nmop-network-incident-yang.md
+++ b/draft-ietf-nmop-network-incident-yang.md
@@ -99,6 +99,15 @@ informative:
    target: https://www.w3.org/TR/2021/REC-trace-context-1-20211123/
    date: 2021
 
+  ITU-T-G-7710:
+    title: ITU-T G.7710/Y.1701 - Common equipment management function requirements
+    target: https://www.itu.int/rec/T-REC-G.7710
+    date: 2020
+
+  ITU-T-X-733:
+    title: ITU-T X.733 - Information technology - Open Systems Interconnection - Systems Management - Alarm reporting function
+    target: https://www.itu.int/rec/T-REC-X.733/fr
+    date: 1999
 
 --- abstract
 
@@ -255,12 +264,12 @@ Root cause:
    an ongoing incident -- specifically regarding network or service impairments
    and their related consequential failures and symptoms -- and prevents the problem
    from recurring. Causality is defined as the implementation of an inductive process
-   at the network or processing element level {{ITU-T-G.7710}} and as a doubt removal
-   process at the Incident management system level {{ITU-T X.733}}. The inductive
+   at the network or processing element level {{ITU-T-G-7710}} and as a doubt removal
+   process at the Incident management system level {{ITU-T-X-733}}. The inductive
    process is based on the distinction made between _primary failures_ (i.e., a failure
    that directly indicates the fault location and initiate a repair action, such as
    a broken cable or a misconnection) and _secondary failures_ (i.e., a consequential
-   failure, such as an upper level service that has gone down) {{ITU-T-G.7710}}.
+   failure, such as an upper level service that has gone down) {{ITU-T-G-7710}}.
 
    Conversely, a causal factor is a contributing action that influences the outcome
    of an incident or event but is not the root cause.

--- a/draft-ietf-nmop-network-incident-yang.md
+++ b/draft-ietf-nmop-network-incident-yang.md
@@ -249,9 +249,16 @@ Incident handler:
 : An entity which can receive network incident notification, store and query the information of
   network incidents for data analysis. It has no control on incident server.
 
-Root cause: A factor is considered the root cause of a problem if removing it prevents the problem from recurring.
-Conversely, a causal factor is a contributing action that affects an incident/event's outcome but is not the
-root cause.
+Root cause:
+:  A factor is considered the root cause of a problem if removing it fully resolves
+   an ongoing incident -- specifically regarding network or service impairments
+   and their related consequential symptoms -- and prevents the problem from recurring.
+   Conversely, a causal factor is a contributing action that influences the outcome
+   of an incident or event but is not the root cause.
+
+  ### Root Cause
+
+      A factor is considered the root cause of a problem if removing it fully resolves an ongoing incidentand prevents the problem from recurring. Conversely, a causal factor is a contributing action that influences the outcome of an incident or event but is not the root cause.
 
 # Sample Use Cases
 


### PR DESCRIPTION
Based on the [IETF 122 Session 1](https://datatracker.ietf.org/meeting/122/materials/agenda-122-nmop-06) discussions, I provide additional details to the "root cause" definition to help common sens understanding, and provide bounds for root cause analysis and network design quality improvement using confidence and attribution categories.

I also propose to use the "algorithmic techniques" term instead of the specific "machine learning" term to open up impact/effect analysis implementation to any AI technique.