### PR TITLE
make incident-no mandatory

### DIFF
--- a/yang/ietf-incident.yang
+++ b/yang/ietf-incident.yang
@@ -478,7 +478,6 @@ module ietf-incident {
        incident.";
     leaf name {
       type string;
-      mandatory true;
       description
         "The name of an incident.";
     }
@@ -486,13 +485,11 @@ module ietf-incident {
       type identityref {
         base incident-class;
       }
-      mandatory true;
       description
         "The type of an incident.";
     }
     leaf incident-id {
       type string;
-      mandatory true;
       description
         "The unique qualifier of an incident instance type.
         This leaf is used when the 'type' leaf cannot

--- a/yang/ietf-incident.yang
+++ b/yang/ietf-incident.yang
@@ -711,7 +711,8 @@ module ietf-incident {
       leaf-list incident-no {
         type incident-ref;
         description
-          "The identifier of an incident instance.";
+          "The unique sequence number of an incident instance
+           based on the name type incident-id keys.";
       }
     }
   }
@@ -725,7 +726,8 @@ module ietf-incident {
       leaf-list incident-no {
         type incident-ref;
         description
-          "The identifier of an incident instance.";
+          "The unique sequence number of an incident instance
+           based on the name type incident-id keys.";
       }
     }
   }
@@ -739,7 +741,8 @@ module ietf-incident {
       leaf-list incident-no {
         type incident-ref;
         description
-          "The identifier of an incident instance.";
+          "The unique sequence number of an incident instance
+           based on the name type incident-id keys.";
       }
     }
   }
@@ -857,7 +860,7 @@ module ietf-incident {
         type uint64;
         mandatory true;
         description
-        "The unique sequence number of the incident instance.";
+        "The unique sequence number of the incident instance based on the name type incident-id keys.";
       }
       uses incident-info;
       uses incident-time-info;

--- a/yang/ietf-incident.yang
+++ b/yang/ietf-incident.yang
@@ -492,6 +492,7 @@ module ietf-incident {
     }
     leaf incident-id {
       type string;
+      mandatory true;
       description
         "The unique qualifier of an incident instance type.
         This leaf is used when the 'type' leaf cannot
@@ -830,6 +831,7 @@ module ietf-incident {
        the incident is raised, updated or cleared.";
     leaf incident-no {
       type incident-ref;
+      mandatory true;
       description
         "The identifier of an incident instance.";
     }


### PR DESCRIPTION
and still use incident-no uniquely identify each RPC